### PR TITLE
Add toggle for child chips

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://github.com/user-attachments/assets/988772c5-2024-48d0-ad0e-8239334ecde0
 
 ---
 
-Additionally, the plugin adds child chips below the ftag chips.
+Additionally, the plugin adds child chips below the ftag chips. This behaviour can be toggled via **Show child chips** in the plugin settings.
 
 https://github.com/user-attachments/assets/32783dba-096c-40b4-96eb-4ea613071cbf
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,22 +59,27 @@ export default class StaticTagChipsPlugin extends PluginWithSettings(
 		);
 	}
 
-	injectChildren() {
-		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-		if (
-			!activeView ||
-			!("file" in activeView && activeView.file instanceof TFile)
-		)
-			return;
-		const currentFile = activeView.file;
+        injectChildren() {
+                const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+                if (
+                        !activeView ||
+                        !("file" in activeView && activeView.file instanceof TFile)
+                )
+                        return;
 
-		const header = activeView.containerEl.querySelector(".view-header");
-		if (!header) return;
+                const existing = activeView.containerEl.querySelector(
+                        ".ftags-children-outer",
+                );
+                if (!this.settings.showChildren) {
+                        existing?.remove();
+                        return;
+                }
 
-		const existing = activeView.containerEl.querySelector(
-			".ftags-children-outer",
-		);
-		if (existing) existing.remove();
+                const currentFile = activeView.file;
+                const header = activeView.containerEl.querySelector(".view-header");
+                if (!header) return;
+
+                if (existing) existing.remove();
 
 		const outer = header.createDiv({
 			cls: "ftags-children-outer",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,8 @@ import Main from "./main";
 import { FolderSuggest } from "../obsidian-reusables/src/FolderSuggest";
 
 export const DEFAULT_SETTINGS = {
-	inbox: "Uncategorized",
+       inbox: "Uncategorized",
+       showChildren: true,
 };
 export class MainPluginSettingsTab extends PluginSettingTab {
 	constructor(
@@ -29,13 +30,26 @@ export class MainPluginSettingsTab extends PluginSettingTab {
 			await this.plugin.saveSettings();
 		};
 
-		new Setting(containerEl)
-			.setName("Inbox folder")
-			.setDesc("Folder where notes without explicit ftags are stored")
-			.addSearch((search) => {
-				search.setValue(this.plugin.settings.inbox).onChange(setInbox);
-				this.suggest = new FolderSuggest(this.app, search.inputEl);
-				this.suggest.onSelect((v) => setInbox(v.path));
-			});
-	}
+               new Setting(containerEl)
+                       .setName("Inbox folder")
+                       .setDesc("Folder where notes without explicit ftags are stored")
+                       .addSearch((search) => {
+                               search.setValue(this.plugin.settings.inbox).onChange(setInbox);
+                               this.suggest = new FolderSuggest(this.app, search.inputEl);
+                               this.suggest.onSelect((v) => setInbox(v.path));
+                       });
+
+               new Setting(containerEl)
+                       .setName("Show child chips")
+                       .setDesc("Display child notes under the tag chips")
+                       .addToggle((toggle) =>
+                               toggle
+                                       .setValue(this.plugin.settings.showChildren)
+                                       .onChange(async (v) => {
+                                               this.plugin.settings.showChildren = v;
+                                               await this.plugin.saveSettings();
+                                               this.plugin.injectChips();
+                                       }),
+                       );
+       }
 }


### PR DESCRIPTION
## Summary
- allow disabling child chips with new `showChildren` setting
- support editing the new setting via plugin options
- hide child chips when `showChildren` is false
- document the setting in the README

## Testing
- `npm run lint` *(fails: Unsafe call errors)*