### PR TITLE
Add MoC chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Higher-level tags ('grandparents') are rendered semi-transparent. The more dista
 
 https://github.com/user-attachments/assets/9e2aef2a-88b8-4502-8668-294d7ef5f1d2
 
-If you have [crosslink-advanced](https://github.com/d7sd6u/obsidian-crosslink-advanced) enabled, a button for adding new tags appears to the left of the tags:
-
-https://github.com/user-attachments/assets/988772c5-2024-48d0-ad0e-8239334ecde0
-
 ---
 
 Additionally, the plugin adds child chips below the ftag chips. Their behaviour is controlled by the **Child chips** option in the plugin settings. You can hide them, show only the first five, or display all children.

--- a/src/main.ts
+++ b/src/main.ts
@@ -332,17 +332,6 @@ export default class StaticTagChipsPlugin extends PluginWithSettings(
 				).open();
 			});
 		};
-		if (this.app.plugins.plugins["crosslink-advanced"]) {
-			const createButton = chipContainer.createSpan({
-				cls: "cm-hashtag cm-hashtag-end cm-hashtag-begin",
-			});
-			createButton.setText("+ Add tag...");
-			createButton.addEventListener("click", () => {
-				this.app.commands.executeCommandById(
-					"crosslink-advanced:add-ftag",
-				);
-			});
-		}
 
 		const visited = new Set(parents.map((v) => v.path));
 		const getNext = (p: typeof parents) =>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import {
-	App,
-	IconName,
-	MarkdownView,
-	Menu,
-	Modal,
-	Platform,
+        App,
+        FuzzySuggestModal,
+        IconName,
+        MarkdownView,
+        Menu,
+        Modal,
+        Platform,
 	setIcon,
 	Setting,
 	setTooltip,
@@ -269,10 +270,22 @@ export default class StaticTagChipsPlugin extends PluginWithSettings(
 		const outer = header.createDiv({
 			cls: "static-tag-chips-container-outer",
 		});
-		const chipContainer = outer.createDiv({
-			cls: "static-tag-chips-container",
-		});
-		header.insertAdjacentElement("afterend", outer);
+                const chipContainer = outer.createDiv({
+                        cls: "static-tag-chips-container",
+                });
+                header.insertAdjacentElement("afterend", outer);
+
+                const addMoc = chipContainer.createSpan({
+                        cls: "cm-hashtag cm-hashtag-end cm-hashtag-begin",
+                });
+                addMoc.setText("+ Add MoC...");
+                addMoc.addEventListener("click", () => {
+                        new AddMocModal(this.app, currentFile, async (file) => {
+                                await this.addMocToFile(file, currentFile);
+                                this.injectChips();
+                        }).open();
+                });
+                chipContainer.prepend(addMoc);
 
 		const fm =
 			this.app.metadataCache.getFileCache(currentFile)?.frontmatter;
@@ -356,11 +369,11 @@ export default class StaticTagChipsPlugin extends PluginWithSettings(
 		}
 	}
 
-	async removeMocFromFile(parent: TFile, file: TFile) {
-		await this.app.fileManager.processFrontMatter(file, (fm) => {
-			let entries = parseFrontMatterStringArray(fm ?? null, "MoCs") ?? [];
-			entries = entries.filter((entry) => {
-				let original = entry;
+        async removeMocFromFile(parent: TFile, file: TFile) {
+                await this.app.fileManager.processFrontMatter(file, (fm) => {
+                        let entries = parseFrontMatterStringArray(fm ?? null, "MoCs") ?? [];
+                        entries = entries.filter((entry) => {
+                                let original = entry;
 				if (original.startsWith("[[") && original.endsWith("]]"))
 					original = original.slice(2, -2);
 				const link = original.includes("|")
@@ -378,9 +391,20 @@ export default class StaticTagChipsPlugin extends PluginWithSettings(
 				entries.push(this.settings.defaultMoc);
 			}
 
-			fm.MoCs = entries;
-		});
-	}
+                        fm.MoCs = entries;
+                });
+        }
+
+        async addMocToFile(parent: TFile, file: TFile) {
+                await this.app.fileManager.processFrontMatter(file, (fm) => {
+                        const entries = parseFrontMatterStringArray(fm ?? null, "MoCs") ?? [];
+                        const link = `[[${this.app.metadataCache.fileToLinktext(parent, file.path)}]]`;
+                        if (!entries.includes(link)) {
+                                entries.push(link);
+                        }
+                        fm.MoCs = entries;
+                });
+        }
 
 	highlightFileEntry(filePath: string) {
 		const entries = document.querySelectorAll(`[data-path="${filePath}"]`);
@@ -445,7 +469,30 @@ export class ConfirmationModal extends Modal {
 					}),
 			);
 		set.settingEl.classList.add("viewer-ftags-custom-setting-el");
-	}
+        }
+}
+
+export class AddMocModal extends FuzzySuggestModal<TFile> {
+        constructor(
+                app: App,
+                private current: TFile,
+                private onSubmit: (file: TFile) => void,
+        ) {
+                super(app);
+                this.setPlaceholder("Choose note to add as MoC");
+        }
+
+        getItems(): TFile[] {
+                return this.app.vault.getMarkdownFiles();
+        }
+
+        getItemText(item: TFile): string {
+                return this.app.metadataCache.fileToLinktext(item, this.current.path);
+        }
+
+        onChooseItem(item: TFile) {
+                this.onSubmit(item);
+        }
 }
 function createTreeItem(
 	path: string,


### PR DESCRIPTION
## Summary
- add "Add MoC" chip for quick linking of new MoCs
- show modal to pick a note
- write the note to frontmatter MoCs field

## Testing
- `npm run typecheck` *(fails: Cannot find module '../obsidian-reusables/src/ftags')*
- `npm run lint` *(fails with 228 errors)*
- `npm run build` *(fails: Could not resolve '../obsidian-reusables/src/PluginWithSettings')*