### PR TITLE
Add spacing for parent chips when children hidden

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -249,9 +249,15 @@ export default class StaticTagChipsPlugin extends PluginWithSettings(
 		this.injectChildren();
 	}
 
-	injectTags() {
-		this.injectChildren();
-		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
+       injectTags() {
+               this.injectChildren();
+               let childMode: ChildrenDisplayMode;
+               if (typeof this.settings.showChildren === "string") {
+                       childMode = this.settings.showChildren as ChildrenDisplayMode;
+               } else {
+                       childMode = this.settings.showChildren ? "limited" : "off";
+               }
+               const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
 		if (
 			!activeView ||
 			!("file" in activeView && activeView.file instanceof TFile)
@@ -267,12 +273,13 @@ export default class StaticTagChipsPlugin extends PluginWithSettings(
 		);
 		if (existing) existing.remove();
 
-		const outer = header.createDiv({
-			cls: "static-tag-chips-container-outer",
-		});
-                const chipContainer = outer.createDiv({
-                        cls: "static-tag-chips-container",
-                });
+               const outer = header.createDiv({
+                       cls: "static-tag-chips-container-outer",
+               });
+               if (childMode === "off") outer.classList.add("children-hidden");
+               const chipContainer = outer.createDiv({
+                       cls: "static-tag-chips-container",
+               });
                 header.insertAdjacentElement("afterend", outer);
 
                 const addMoc = chipContainer.createSpan({

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,7 +16,12 @@
 }
 .static-tag-chips-container-outer,
 .ftags-children-outer {
-	padding: 0 var(--file-margins);
+        padding: 0 var(--file-margins);
+}
+
+/* Add space below parent chips when children are hidden */
+.static-tag-chips-container-outer.children-hidden {
+        margin-bottom: 2px;
 }
 .viewer-ftag-tag-chip-layer-first {
 	opacity: 1;


### PR DESCRIPTION
## Summary
- add a `children-hidden` CSS rule with 2px margin-bottom
- toggle this class on the parent chip container based on the `Child chips` setting

## Testing
- `npm run lint` *(fails: Unsafe call typed value)*
- `npm run typecheck` *(fails: cannot find module and other TS errors)*